### PR TITLE
Update SELinux contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ansible-role-zabbix-server
 =========
+[![Build Status](https://travis-ci.com/AFCYBER-DREAM/ansible-role-zabbix-server.svg?branch=master)](https://travis-ci.com/AFCYBER-DREAM/ansible-role-zabbix-server)
 
 Deploys a zabbix server and web front end
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,9 +17,11 @@ zabbix_packages:
 
 zabbix_security:
   selinux_te_files:
-    - {name: "zabbix_sock", version: "1.0", te_file: "zabbix_sock.te"}
+    - {name: "zabbix_sock", version: "1.1", te_file: "zabbix_sock.te"}
   security_ports:
     - {port: 3306, protocol: 'tcp', port_type: 'mysqld_port_t'}
+    - {port: 80, protocol: 'tcp'}
+    - {port: 443, protocol: 'tcp'}
   sebooleans:
     - {name: 'httpd_can_network_connect_db', state: yes}
     - {name: "httpd_can_connect_zabbix", state: yes}

--- a/files/zabbix_sock.te
+++ b/files/zabbix_sock.te
@@ -1,12 +1,14 @@
 
-module zabbix_sock 1.0;
+module zabbix_sock 1.1;
 
 require {
         type zabbix_var_run_t;
         type zabbix_t;
+        class process setrlimit;
         class sock_file { create unlink };
 }
 
 #============= zabbix_t ==============
 allow zabbix_t zabbix_var_run_t:sock_file create;
 allow zabbix_t zabbix_var_run_t:sock_file unlink;
+allow zabbix_t self:process setrlimit;


### PR DESCRIPTION
When testing after deployment we discovered that we need an additional
selinux role that needed to be added to the te file. Update repo
location for internal mirrors. Added travis ci badge to the README file